### PR TITLE
Exclude liteloader and base edits from compiling with forge.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,15 @@ processResources
         exclude 'mcmod.info'
     }
 }
+sourceSets {
+	main {
+		java {
+			exclude 'acs/tabbychat/liteloader/**'
+			exclude 'net/**'
+		}
+	}
+}
 dependencies {
 	compile 'junit:junit:4.8.1'
+	compile 'org.lwjgl.lwjgl:lwjgl:2.9.0'
 }


### PR DESCRIPTION
LiteLoader may be included when I figure out how to do it.  Base edits
will not.
